### PR TITLE
Add initial custom version of Spark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target
+
+pyspark-*.tar.gz

--- a/README.md
+++ b/README.md
@@ -7,6 +7,49 @@ Supports the current versions:
 - 3.4.1 => EMR 6.13
 - 3.3.0 => Glue 4.0
 
+Note, the `pom.xml` file includes all the dependencies to be added to the custom version of spark. If that changes, then the artifacts will need to be rebuilt.
+
 ## Building Spark
+
+1. First, you need to build the Glue Data Catalog client
+   [here](https://github.com/awslabs/aws-glue-data-catalog-client-for-apache-hive-metastore). This installation process includes building a custom version of hive, during which the jars will be installed locally (under version `2.3.10-SNAPSHOT`). 
+
+1. Once this is completed, you need to also build Spark. First step is to clone the [repository](https://github.com/apache/spark). 
+
+1. One this is completed, then you can simply run the following script from the current repository: 
+
+    ```
+    ./generate-spark-distro.sh /path/to/spark/repo
+    ```
+
+    For more details, see the [Spark documentation](https://spark.apache.org/docs/latest/building-spark.html).
+    This takes a while to run. 
+    
+1. Once this is complete, you should see two new tar.gz files in the directory: 
+
+    ```
+    > ls *.tar.gz
+    -rw-r--r--  1 user  group  534842354 Jan 15 13:41 pyspark-3.3.0.tar.gz
+    -rw-------  1 user  group  114294784 Jan 15 13:41 pyspark-3.4.1.tar.gz
+
+    ```
+
+    These are now installable with pip. You can test, if you wish, by running:
+
+   
+    ```
+    pip install pyspark-3.4.1.tar.gz
+    ```
+
+## Releasing versions
+
+To release a new version of the custom artifact, simply create a new release, and add the files to it. For example: 
+
+```
+gh release create "release/2024.01.15" -t "Initial release of custom spark"
+gh release upload "release/2024.01.15" pyspark-*.tar.gz
+```
+
+
 
 

--- a/generate-spark-distro.sh
+++ b/generate-spark-distro.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+SPARK_BASE_PATH=$1
+REPO_PATH=${PWD}
+
+export JAVA_HOME=$(/usr/libexec/java_home -v 11)
+
+VERSIONS=( '3.3.0' '3.4.1')
+
+for version in "${VERSIONS[@]}"
+do
+  echo "Running for $version"
+
+  cd $SPARK_BASE_PATH
+
+  git checkout tags/v$version
+
+  mvn clean
+  ./dev/make-distribution.sh --name tado-aws-custom-spark --pip \
+      --tgz -Phive -Pmesos -Pyarn -Phadoop-cloud \
+      -Dhive.version=2.3.10-SNAPSHOT -Dhive23.version=2.3.10-SNAPSHOT
+
+  cd $REPO_PATH
+
+  major_version=$(echo $version | cut -d. -f1 -f2)
+
+  mvn clean dependency:copy-dependencies \
+	  -Dspark.full_version=$version \
+	  -Dspark.version=$major_version \
+	  -DoutputDirectory=$SPARK_BASE_PATH/assembly/target/scala-2.12/jars
+
+  cd $SPARK_BASE_PATH/python
+
+  python setup.py sdist
+
+  cp dist/pyspark-${version}.tar.gz $REPO_PATH
+done

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,118 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.tado.custom-spark</groupId>
+	<artifactId>deps</artifactId>
+	<version>0.0</version>
+	<packaging>jar</packaging>
+
+	<name>tado Custom Spark Depencencies</name>
+
+	<properties>
+		<spark.full_version>3.4.1</spark.full_version>
+		<spark.version>3.4</spark.version>
+		<scala.binary.version>2.12</scala.binary.version>
+		<iceberg.version>1.4.3</iceberg.version>
+		<awssdk.version>2.20.118</awssdk.version>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>glue</artifactId>
+			<version>${awssdk.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpclient</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpcore</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-codec</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.netty</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>sts</artifactId>
+			<version>${awssdk.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>s3</artifactId>
+			<version>${awssdk.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>dynamodb</artifactId>
+			<version>${awssdk.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>kms</artifactId>
+			<version>${awssdk.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>url-connection-client</artifactId>
+			<version>${awssdk.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws.glue</groupId>
+			<artifactId>aws-glue-datacatalog-spark-client</artifactId>
+			<version>3.4.0-SNAPSHOT</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpclient</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.iceberg</groupId>
+			<artifactId>iceberg-spark-runtime-${spark.version}_${scala.binary.version}</artifactId>
+			<version>${iceberg.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+	</build>
+</project>


### PR DESCRIPTION
This include versions:

- 3.4.1 => used on EMR >= 6.13
- 3.3.0 => used on AWS Glue

It includes additional jars, including:

- Iceberg
- AWS SDK packages for Iceberg
- hadoop-cloud (needed to access S3)
- Glue Catalog (built according to https://github.com/awslabs/aws-glue-data-catalog-client-for-apache-hive-metastore)

This should simplify our testing and local usage of Spark.
