### PR TITLE
Fix Spark Dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -12,20 +12,22 @@ Note, the `pom.xml` file includes all the dependencies to be added to the custom
 ## Building Spark
 
 1. First, you need to build the Glue Data Catalog client
-   [here](https://github.com/awslabs/aws-glue-data-catalog-client-for-apache-hive-metastore). This installation process includes building a custom version of hive, during which the jars will be installed locally (under version `2.3.10-SNAPSHOT`). 
+   [here](https://github.com/awslabs/aws-glue-data-catalog-client-for-apache-hive-metastore).
+   The only difference is that one should checkout the `rel/release-2.3.9` branch.
+   This installation process includes building a custom version of hive, during which the jars will be installed locally (under version `2.3.9`). Note, I had trouble with the compiling tests, so added `-Dmaven.test.skip=true` to the build command to not compile those.
 
-1. Once this is completed, you need to also build Spark. First step is to clone the [repository](https://github.com/apache/spark). 
+1. Once this is completed, you need to also build Spark. First step is to clone the [repository](https://github.com/apache/spark).
 
-1. One this is completed, then you can simply run the following script from the current repository: 
+1. One this is completed, then you can simply run the following script from the current repository:
 
     ```
     ./generate-spark-distro.sh /path/to/spark/repo
     ```
 
     For more details, see the [Spark documentation](https://spark.apache.org/docs/latest/building-spark.html).
-    This takes a while to run. 
-    
-1. Once this is complete, you should see two new tar.gz files in the directory: 
+    This takes a while to run.
+
+1. Once this is complete, you should see two new tar.gz files in the directory:
 
     ```
     > ls *.tar.gz
@@ -36,20 +38,59 @@ Note, the `pom.xml` file includes all the dependencies to be added to the custom
 
     These are now installable with pip. You can test, if you wish, by running:
 
-   
+
     ```
     pip install pyspark-3.4.1.tar.gz
     ```
 
 ## Releasing versions
 
-To release a new version of the custom artifact, simply create a new release, and add the files to it. For example: 
+To release a new version of the custom artifact, simply create a new release, and add the files to it. For example:
 
 ```
 gh release create "release/2024.01.15" -t "Initial release of custom spark"
 gh release upload "release/2024.01.15" pyspark-*.tar.gz
 ```
 
+Please also specify the sha256 sum values for each in the release notes, e.g.:
 
+```
+> sha256sum *.tar.gz
+e6b24c4ff740504a1aadb03d330c6a393a3b2b00c3dc827906195cf0b32cc822  pyspark-3.3.0.tar.gz
+efacea7c1df7db7b4e00d5adc2dc4a6488703181260424df2b8418dc34604175  pyspark-3.4.1.tar.gz
+```
 
+## Installing versions from this repository
 
+To install a version from this repository, reference the artifact explicitly, and provide it's sha256 sum value. An example is:
+
+```
+pip install https://github.com/tadodotcom/data-spark/releases/download/release%2F2024.01.17/pyspark-3.4.1.tar.gz#sha256=efacea7c1df7db7b4e00d5adc2dc4a6488703181260424df2b8418dc34604175
+```
+
+**Important issues**:
+
+- `pipenv` has trouble with packages that reference this in their setup files (e.g. tado-ds-utils), and does not explicitly list it then in the `Pipenv.lock` file. A workaround is to explicitly reference this in the `Pipfile`, e.g.:
+
+    ```
+    pyspark = { path = "https://github.com/tadodotcom/data-spark/releases/download/release%2F2024.01.17/pyspark-3.4.1.tar.gz#sha256=efacea7c1df7db7b4e00d5adc2dc4a6488703181260424df2b8418dc34604175" }
+    ```
+
+- To enable using the Glue Metastore, the spark session needs to be started with specific variables set, e.g.:
+
+    ```python
+    # Using tado_ds_utils
+    get_spark_session(
+       "my_session"
+       SparkConf()
+       .set(
+           "spark.hadoop.hive.metastore.client.factory.class",
+           "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+       ).set(
+           "spark.hadoop.hive.imetastoreclient.factory.class",
+           "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+       ),
+    )
+    ```
+
+Note that you *cannot* have multiple Hive metastores! This means, e.g. if you want to only work locally, then you cannot set these variables. You also will need to fully restart the SparkSession (e.g. reboot the python kernel, when running in the notebook, or simply restarting the pyspark process) if you need to change this setting.

--- a/generate-spark-distro.sh
+++ b/generate-spark-distro.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
+set -e
 
 SPARK_BASE_PATH=$1
 REPO_PATH=${PWD}
 
 export JAVA_HOME=$(/usr/libexec/java_home -v 11)
 
-VERSIONS=( '3.3.0' '3.4.1')
+VERSIONS=( '3.3.0' '3.4.1' )
 
 for version in "${VERSIONS[@]}"
 do
@@ -15,10 +16,13 @@ do
 
   git checkout tags/v$version
 
-  mvn clean
+  ./build/mvn clean
+
+
   ./dev/make-distribution.sh --name tado-aws-custom-spark --pip \
-      --tgz -Phive -Pmesos -Pyarn -Phadoop-cloud \
-      -Dhive.version=2.3.10-SNAPSHOT -Dhive23.version=2.3.10-SNAPSHOT
+      --tgz -Phive -Phive-thriftserver -Pmesos -Pyarn -Phadoop-cloud \
+      -DskipTests \
+      -Dmaven.test.skip=true
 
   cd $REPO_PATH
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,60 +37,7 @@ under the License.
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 	</properties>
-
 	<dependencies>
-		<dependency>
-			<groupId>software.amazon.awssdk</groupId>
-			<artifactId>glue</artifactId>
-			<version>${awssdk.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.httpcomponents</groupId>
-					<artifactId>httpclient</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.httpcomponents</groupId>
-					<artifactId>httpcore</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>commons-codec</groupId>
-					<artifactId>*</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>io.netty</groupId>
-					<artifactId>*</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>software.amazon.awssdk</groupId>
-			<artifactId>sts</artifactId>
-			<version>${awssdk.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>software.amazon.awssdk</groupId>
-			<artifactId>s3</artifactId>
-			<version>${awssdk.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>software.amazon.awssdk</groupId>
-			<artifactId>dynamodb</artifactId>
-			<version>${awssdk.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>software.amazon.awssdk</groupId>
-			<artifactId>kms</artifactId>
-			<version>${awssdk.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>software.amazon.awssdk</groupId>
-			<artifactId>url-connection-client</artifactId>
-			<version>${awssdk.version}</version>
-		</dependency>
 		<dependency>
 			<groupId>com.amazonaws.glue</groupId>
 			<artifactId>aws-glue-datacatalog-spark-client</artifactId>
@@ -104,11 +51,20 @@ under the License.
 					<groupId>commons-logging</groupId>
 					<artifactId>commons-logging</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.iceberg</groupId>
 			<artifactId>iceberg-spark-runtime-${spark.version}_${scala.binary.version}</artifactId>
+			<version>${iceberg.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.iceberg</groupId>
+			<artifactId>iceberg-aws-bundle</artifactId>
 			<version>${iceberg.version}</version>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION

- Update README with more information about releases
- Fix Spark build script to include hive-thriftserver
- Reduce extra dependencies needed (use the aws deps bundled by iceberg)
