### PR TITLE
Build fat, shaded jar for custom external dependencies

### DIFF
--- a/generate-spark-distro.sh
+++ b/generate-spark-distro.sh
@@ -28,10 +28,8 @@ do
 
   major_version=$(echo $version | cut -d. -f1 -f2)
 
-  mvn clean dependency:copy-dependencies \
-	  -Dspark.full_version=$version \
-	  -Dspark.version=$major_version \
-	  -DoutputDirectory=$SPARK_BASE_PATH/assembly/target/scala-2.12/jars
+  mvn clean package
+  cp target/tado-custom-spark* $SPARK_BASE_PATH/assembly/target/scala-2.12/jars/
 
   cd $SPARK_BASE_PATH/python
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.tado.custom-spark</groupId>
-	<artifactId>deps</artifactId>
-	<version>0.0</version>
+	<artifactId>tado-custom-spark</artifactId>
+	<version>2024.01.18</version>
 	<packaging>jar</packaging>
 
 	<name>tado Custom Spark Depencencies</name>
@@ -70,5 +70,31 @@ under the License.
 	</dependencies>
 
 	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.4.1</version>
+				<executions>
+					<!-- Run shade goal on package phase -->
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<createDependencyReducedPom>false</createDependencyReducedPom>
+							<relocations>
+								<relocation>
+									<pattern>com.fasterxml.jackson</pattern>
+									<shadedPattern>com.tado.data.fasterxml.jackson</shadedPattern>
+								</relocation>
+							</relocations>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
 	</build>
+
 </project>


### PR DESCRIPTION
During test it became clear that several dependencies could not simply
be removed, but actually needed to be shaded to deal with
incompabilities with spark.

This PR exports the custom dependencies as a single, fat jar, and adds
shading for `com.jackson` databinding (which has incompatible versions
between the AWS SDK and Spark).
