### PR TITLE
Upgrade to use Spark 3.5.1

### DIFF
--- a/generate-spark-distro.sh
+++ b/generate-spark-distro.sh
@@ -6,7 +6,7 @@ REPO_PATH=${PWD}
 
 export JAVA_HOME=$(/usr/libexec/java_home -v 11)
 
-VERSIONS=( '3.3.0' '3.4.1' )
+VERSIONS=( '3.3.0' '3.5.1' )
 
 for version in "${VERSIONS[@]}"
 do

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@ under the License.
 		<spark.full_version>3.4.1</spark.full_version>
 		<spark.version>3.4</spark.version>
 		<scala.binary.version>2.12</scala.binary.version>
-		<iceberg.version>1.4.3</iceberg.version>
+		<iceberg.version>1.5.2</iceberg.version>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 	</properties>


### PR DESCRIPTION
This is to enable us to migrate to use EMR-7.1. Note, this release will
*not* include a Glue release (3.3).
