### PR TITLE
Bump Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Provides a custom Spark distribution to be able to easily use the Glue Catalog (
 
 Supports the current versions:
 
-- 3.4.1 => EMR 6.13
+- 3.5.3 => EMR 7.x (3.5.3 is not yet in use, 3.5.1 a of 7.3.0)
 - 3.3.0 => Glue 4.0
 
 Note, the `pom.xml` file includes all the dependencies to be added to the custom version of spark. If that changes, then the artifacts will need to be rebuilt.

--- a/generate-spark-distro.sh
+++ b/generate-spark-distro.sh
@@ -6,7 +6,7 @@ REPO_PATH=${PWD}
 
 export JAVA_HOME=$(/usr/libexec/java_home -v 11)
 
-VERSIONS=( '3.3.0' '3.5.1' )
+VERSIONS=( '3.3.0' '3.5.3' )
 
 for version in "${VERSIONS[@]}"
 do

--- a/pom.xml
+++ b/pom.xml
@@ -29,10 +29,10 @@ under the License.
 	<name>tado Custom Spark Depencencies</name>
 
 	<properties>
-		<spark.full_version>3.4.1</spark.full_version>
-		<spark.version>3.4</spark.version>
+		<spark.full_version>3.5.3</spark.full_version>
+		<spark.version>3.5</spark.version>
 		<scala.binary.version>2.12</scala.binary.version>
-		<iceberg.version>1.5.2</iceberg.version>
+		<iceberg.version>1.6.1</iceberg.version>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 	</properties>


### PR DESCRIPTION
Spark => 3.5.3, Iceberg => 1.6.1

This does not include an update to the 3.3.0 spark distribution
